### PR TITLE
Patch - link to directory, not README directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Meetup of ScalaTaiwan
 
 ## 2017
-* [We use Scala in the real world](2017-03-09-We_Use_Scala_In_The_Real_World/README.md) by [pandaforme](https://github.com/pandaforme)
-* [Testing Upside Down](2017-02-15-Testing_Upside_Down/README.md) by [Jiří Jakeš](https://github.com/jirijakes)
-* [Device Simulator with Akka](2017-01-11-Device_Simulator_with_Akka/README.md) by [maxxhuang](https://github.com/maxxhuang)
+* [We use Scala in the real world](2017-03-09-We_Use_Scala_In_The_Real_World/) by [pandaforme](https://github.com/pandaforme)
+* [Testing Upside Down](2017-02-15-Testing_Upside_Down/) by [Jiří Jakeš](https://github.com/jirijakes)
+* [Device Simulator with Akka](2017-01-11-Device_Simulator_with_Akka/) by [maxxhuang](https://github.com/maxxhuang)
 
 ## 2016
-* [Liberate Your Monads](2016-12-21-Liberate_Your_Monads/README.md) by [Jiří Jakeš](https://github.com/jirijakes)
+* [Liberate Your Monads](2016-12-21-Liberate_Your_Monads/) by [Jiří Jakeš](https://github.com/jirijakes)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Meetup of ScalaTaiwan
+# Scala Taiwan Meetups
 
 ## 2017
 * [We use Scala in the real world](2017-03-09-We_Use_Scala_In_The_Real_World/) by [pandaforme](https://github.com/pandaforme)


### PR DESCRIPTION
It should be link to directory, not just README.md. 
Or it would not easily to get the slides.
Sorry for so many PRs.